### PR TITLE
Import stopwords library from nltk.corpus

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,8 @@ from email.mime.application import MIMEApplication
 from email import encoders
 # '------------------'
 from gliner import GLiNER
+# '------------------'
+from nltk.corpus import stopwords
 # -------------------
 from langchain_community.llms.ollama import Ollama
 print("***************************************************************")


### PR DESCRIPTION
Include "from nltk.corpus import stopwords" (library) which is necessary for the remove_stopwords function which I forgot to mention in the previous pull request.